### PR TITLE
Use h2 database instead of mysql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dependency-reduced-pom.xml
 
 # Generated when running app
 logs/
+db.*.db

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -7,13 +7,13 @@ logging:
   level: INFO
 
 database:
-  driverClass: com.mysql.jdbc.Driver
+  driverClass: org.h2.Driver
   user: demo_user
   password: demopassword
-  url: jdbc:mysql://localhost:3306/demo
+  url: jdbc:h2:./db
 
 jooq:
-  dialect: MYSQL
+  dialect: H2
   logExecutedSql: yes
   renderSchema: yes
   renderNameStyle: QUOTED

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <dropwizard.version>1.0.5</dropwizard.version>
         <mainClass>com.uberlogik.demo.DemoApplication</mainClass>
         <jooq.version>3.8.6</jooq.version>
-        <driver.version>5.1.40</driver.version>
+        <driver.version>1.4.193</driver.version>
         <pac4j.version>1.9.4</pac4j.version>
     </properties>
 
@@ -36,9 +36,10 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <version>${driver.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
@@ -93,8 +94,8 @@
 
                 <dependencies>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
                         <version>${driver.version}</version>
                     </dependency>
 
@@ -102,8 +103,8 @@
 
                 <configuration>
                     <jdbc>
-                        <driver>com.mysql.jdbc.Driver</driver>
-                        <url>jdbc:mysql://localhost:3306/demo</url>
+                        <driver>org.h2.Driver</driver>
+                        <url>jdbc:h2:${basedir}/db</url>
                         <user>demo_user</user>
                         <password>demopassword</password>
                     </jdbc>
@@ -117,9 +118,9 @@
                             <daos>true</daos>
                         </generate>
                         <database>
-                            <name>org.jooq.util.mysql.MySQLDatabase</name>
+                            <name>org.jooq.util.h2.H2Database</name>
                             <includes>.*</includes>
-                            <inputSchema>demo</inputSchema>
+                            <inputSchema>PUBLIC</inputSchema>
                         </database>
                         <target>
                             <packageName>com.uberlogik.demo.db</packageName>


### PR DESCRIPTION
Hi,

Here is one change to simplify the use of the demo by relying on file-based h2 database.

For the record, h2-console (provided by h2 itself) is a nice application to browse it and execute SQL.

Maybe it could be nice to use dropwizard-migrate to manage db schemas instead?